### PR TITLE
fix: s3 lifecycle rule update to avoid warning

### DIFF
--- a/logs.tf
+++ b/logs.tf
@@ -81,6 +81,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
     expiration {
       days = var.logging.retention_days
     }
+    filter {
+      prefix = ""
+    }
     status = "Enabled"
   }
 }


### PR DESCRIPTION
This will fix the following warning during terraform apply:

`Warning: Invalid Attribute Combination`
` `
`  with module.cdn.aws_s3_bucket_lifecycle_configuration.logs,`
`  on /tmp/terraform-data-dir/modules/cdn/logs.tf line 79, in resource "aws_s3_bucket_lifecycle_configuration" "logs":`
`  79:   rule {`
` `
`No attribute specified when one (and only one) of [rule[0].prefix.<.filter]`
`is required`
` `
`This will be an error in a future version of the provider`
